### PR TITLE
virt: handle Virtualbox 5.0 with kvm hypervisor

### DIFF
--- a/src/shared/virt.c
+++ b/src/shared/virt.c
@@ -151,7 +151,7 @@ int detect_vm(const char **id) {
         _cleanup_free_ char *domcap = NULL, *cpuinfo_contents = NULL;
         static thread_local int cached_found = -1;
         static thread_local const char *cached_id = NULL;
-        const char *_id = NULL;
+        const char *_id = NULL, *_id_cpuid = NULL;
         int r;
 
         if (_likely_(cached_found >= 0)) {
@@ -197,10 +197,26 @@ int detect_vm(const char **id) {
 
         /* this will set _id to "other" and return 0 for unknown hypervisors */
         r = detect_vm_cpuid(&_id);
-        if (r != 0)
+
+        /* finish when found a known hypervisor other than kvm */
+        if (r < 0 || (r > 0 && !streq(_id, "kvm")))
                 goto finish;
 
+        _id_cpuid = _id;
+
         r = detect_vm_dmi(&_id);
+
+        /* kvm with and without Virtualbox */
+        if (streq_ptr(_id_cpuid, "kvm")) {
+                if (r > 0 && streq(_id, "oracle"))
+                        goto finish;
+
+                _id = _id_cpuid;
+                r = 1;
+                goto finish;
+        }
+
+        /* information from dmi */
         if (r != 0)
                 goto finish;
 


### PR DESCRIPTION
This essentially is a backport of e32886e to fix NixOS/nixpkgs##9876 as applied in NixOS/nixpkgs@389e654e0398a1ea64a58cca667808fe453a7611.
