### PR TITLE
Disable dbus methods that change system state

### DIFF
--- a/src/hostname/hostnamed.c
+++ b/src/hostname/hostnamed.c
@@ -415,6 +415,9 @@ static int method_set_hostname(sd_bus_message *m, void *userdata, sd_bus_error *
         if (r < 0)
                 return r;
 
+        return sd_bus_error_setf(error, SD_BUS_ERROR_NOT_SUPPORTED,
+            "Changing system settings via systemd is not supported on NixOS.");
+
         if (isempty(name))
                 name = c->data[PROP_STATIC_HOSTNAME];
 
@@ -473,6 +476,9 @@ static int method_set_static_hostname(sd_bus_message *m, void *userdata, sd_bus_
         r = sd_bus_message_read(m, "sb", &name, &interactive);
         if (r < 0)
                 return r;
+
+        return sd_bus_error_setf(error, SD_BUS_ERROR_NOT_SUPPORTED,
+            "Changing system settings via systemd is not supported on NixOS.");
 
         if (isempty(name))
                 name = NULL;
@@ -540,6 +546,9 @@ static int set_machine_info(Context *c, sd_bus_message *m, int prop, sd_bus_mess
         r = sd_bus_message_read(m, "sb", &name, &interactive);
         if (r < 0)
                 return r;
+
+        return sd_bus_error_setf(error, SD_BUS_ERROR_NOT_SUPPORTED,
+            "Changing system settings via systemd is not supported on NixOS.");
 
         if (isempty(name))
                 name = NULL;

--- a/src/locale/localed.c
+++ b/src/locale/localed.c
@@ -902,6 +902,9 @@ static int method_set_locale(sd_bus_message *m, void *userdata, sd_bus_error *er
         if (r < 0)
                 return r;
 
+        return sd_bus_error_setf(error, SD_BUS_ERROR_NOT_SUPPORTED,
+            "Changing system settings via systemd is not supported on NixOS.");
+
         /* Check whether a variable changed and if it is valid */
         STRV_FOREACH(i, l) {
                 bool valid = false;
@@ -1039,6 +1042,9 @@ static int method_set_vc_keyboard(sd_bus_message *m, void *userdata, sd_bus_erro
         if (r < 0)
                 return r;
 
+        return sd_bus_error_setf(error, SD_BUS_ERROR_NOT_SUPPORTED,
+            "Changing system settings via systemd is not supported on NixOS.");
+
         if (isempty(keymap))
                 keymap = NULL;
 
@@ -1160,6 +1166,9 @@ static int method_set_x11_keyboard(sd_bus_message *m, void *userdata, sd_bus_err
         r = sd_bus_message_read(m, "ssssbb", &layout, &model, &variant, &options, &convert, &interactive);
         if (r < 0)
                 return r;
+
+        return sd_bus_error_setf(error, SD_BUS_ERROR_NOT_SUPPORTED,
+            "Changing system settings via systemd is not supported on NixOS.");
 
         if (isempty(layout))
                 layout = NULL;

--- a/src/timedate/timedated.c
+++ b/src/timedate/timedated.c
@@ -351,6 +351,9 @@ static int method_set_timezone(sd_bus_message *m, void *userdata, sd_bus_error *
         if (r < 0)
                 return r;
 
+        return sd_bus_error_setf(error, SD_BUS_ERROR_NOT_SUPPORTED,
+            "Changing system settings via systemd is not supported on NixOS.");
+
         if (!timezone_is_valid(z))
                 return sd_bus_error_setf(error, SD_BUS_ERROR_INVALID_ARGS, "Invalid time zone '%s'", z);
 
@@ -421,6 +424,9 @@ static int method_set_local_rtc(sd_bus_message *m, void *userdata, sd_bus_error 
         r = sd_bus_message_read(m, "bbb", &lrtc, &fix_system, &interactive);
         if (r < 0)
                 return r;
+
+        return sd_bus_error_setf(error, SD_BUS_ERROR_NOT_SUPPORTED,
+            "Changing system settings via systemd is not supported on NixOS.");
 
         if (lrtc == c->local_rtc)
                 return sd_bus_reply_method_return(m, NULL);
@@ -511,6 +517,9 @@ static int method_set_time(sd_bus_message *m, void *userdata, sd_bus_error *erro
         assert(m);
         assert(c);
 
+        return sd_bus_error_setf(error, SD_BUS_ERROR_NOT_SUPPORTED,
+            "Changing system settings via systemd is not supported on NixOS.");
+
         if (c->use_ntp)
                 return sd_bus_error_setf(error, BUS_ERROR_AUTOMATIC_TIME_SYNC_ENABLED, "Automatic time synchronization is enabled");
 
@@ -596,6 +605,9 @@ static int method_set_ntp(sd_bus_message *m, void *userdata, sd_bus_error *error
         r = sd_bus_message_read(m, "bb", &enabled, &interactive);
         if (r < 0)
                 return r;
+
+        return sd_bus_error_setf(error, SD_BUS_ERROR_NOT_SUPPORTED,
+            "Changing system settings via systemd is not supported on NixOS.");
 
         if ((bool)enabled == c->use_ntp)
                 return sd_bus_reply_method_return(m, NULL);


### PR DESCRIPTION
Right now, the hostnamed, localed, and timedated services are disabled at compile time [because they can change the system state](https://github.com/NixOS/nixos/issues/82#issuecomment-13174602).  However this disables the useful hostnamectl, timedatectl, and localectl utilities as well.

This PR disables the problematic dbus methods in those services by making them return error messages.  These error messages are reported when trying to call `localectl set-locale de` for example.

After these methods are disabled, all that remains is [enabling the configure flags and enabling the services](https://github.com/gebner/nixpkgs/commit/3630deddda6bbf57ba942389e0248624d6bcc938) to make timedatectl, localectl, and hostnamectl work on NixOS.
