### PR TITLE
networkd: Don't drop addresses from loopback interface

### DIFF
--- a/src/network/networkd-link.c
+++ b/src/network/networkd-link.c
@@ -2040,9 +2040,13 @@ static int link_configure(Link *link) {
         assert(link->network);
         assert(link->state == LINK_STATE_PENDING);
 
-        r = link_drop_foreign_config(link);
-        if (r < 0)
-                return r;
+        /* Drop foreign config, but ignore loopback device.
+         * We do not want to remove loopback address. */
+        if (!(link->flags & IFF_LOOPBACK)) {
+                r = link_drop_foreign_config(link);
+                if (r < 0)
+                        return r;
+        }
 
         r = link_set_bridge_fdb(link);
         if (r < 0)


### PR DESCRIPTION
Another upstream regression, which was not covered by our test suite.

So I've added a test in NixOS/nixpkgs@4c61faa009df175b77148ce587ade14fe9b31b12 so that this doesn't happen again in the future.

This commit is cherry-picked from systemd/systemd#2024 and has already been merged into upstream `master`.

@edolstra: Can you please merge/cherry-pick this to `nixos-v228` and update the systemd rev/hash in `<nixpkgs>`? Thanks :-)

Also, in the long run we should configure `lo` _explicitly_ by default and not rely on it to be configured implicitly.
