### PR TITLE
Fix hwdb paths

### DIFF
--- a/src/libsystemd/sd-hwdb/sd-hwdb.c
+++ b/src/libsystemd/sd-hwdb/sd-hwdb.c
@@ -270,13 +270,8 @@ static int trie_search_f(sd_hwdb *hwdb, const char *search) {
 }
 
 static const char hwdb_bin_paths[] =
-        "/etc/systemd/hwdb/hwdb.bin\0"
         "/etc/udev/hwdb.bin\0"
-        "/usr/lib/systemd/hwdb/hwdb.bin\0"
-#ifdef HAVE_SPLIT_USR
-        "/lib/systemd/hwdb/hwdb.bin\0"
-#endif
-        UDEVLIBEXECDIR "/hwdb.bin\0";
+        ;
 
 _public_ int sd_hwdb_new(sd_hwdb **ret) {
         _cleanup_(sd_hwdb_unrefp) sd_hwdb *hwdb = NULL;


### PR DESCRIPTION
This moves patch from https://github.com/NixOS/nixpkgs/blob/master/pkgs/os-specific/linux/systemd/hwdb-location.diff to our fork repository, originally from @vcunat.

@vcunat, do you mind this? Also, how should I credit you in the commit message -- maybe you want to do the PR by yourself?
