### PR TITLE
Change /usr/share/zoneinfo to /etc/zoneinfo

### DIFF
--- a/man/localtime.xml
+++ b/man/localtime.xml
@@ -54,7 +54,7 @@
   </refnamediv>
 
   <refsynopsisdiv>
-    <para><filename>/etc/localtime</filename> -&gt; <filename>../usr/share/zoneinfo/…</filename></para>
+    <para><filename>/etc/localtime</filename> -&gt; <filename>zoneinfo/…</filename></para>
   </refsynopsisdiv>
 
   <refsect1>
@@ -64,7 +64,7 @@
     system-wide timezone of the local system that is used by
     applications for presentation to the user. It should be an
     absolute or relative symbolic link pointing to
-    <filename>/usr/share/zoneinfo/</filename>, followed by a timezone
+    <filename>/etc/zoneinfo/</filename>, followed by a timezone
     identifier such as <literal>Europe/Berlin</literal> or
     <literal>Etc/UTC</literal>. The resulting link should lead to the
     corresponding binary

--- a/src/basic/time-util.c
+++ b/src/basic/time-util.c
@@ -1037,7 +1037,7 @@ int get_timezones(char ***ret) {
         n_allocated = 2;
         n_zones = 1;
 
-        f = fopen("/usr/share/zoneinfo/zone.tab", "re");
+        f = fopen("/etc/zoneinfo/zone.tab", "re");
         if (f) {
                 char l[LINE_MAX];
 
@@ -1118,7 +1118,7 @@ bool timezone_is_valid(const char *name) {
         if (slash)
                 return false;
 
-        t = strjoina("/usr/share/zoneinfo/", name);
+        t = strjoina("/etc/zoneinfo/", name);
         if (stat(t, &st) < 0)
                 return false;
 
@@ -1189,9 +1189,9 @@ int get_timezone(char **tz) {
         if (r < 0)
                 return r; /* returns EINVAL if not a symlink */
 
-        e = path_startswith(t, "/usr/share/zoneinfo/");
+        e = path_startswith(t, "/etc/zoneinfo/");
         if (!e)
-                e = path_startswith(t, "../usr/share/zoneinfo/");
+                e = path_startswith(t, "zoneinfo/");
         if (!e)
                 return -EINVAL;
 

--- a/src/firstboot/firstboot.c
+++ b/src/firstboot/firstboot.c
@@ -346,7 +346,7 @@ static int process_timezone(void) {
         if (isempty(arg_timezone))
                 return 0;
 
-        e = strjoina("../usr/share/zoneinfo/", arg_timezone);
+        e = strjoina("zoneinfo/", arg_timezone);
 
         mkdir_parents(etc_localtime, 0755);
         if (symlink(e, etc_localtime) < 0)

--- a/src/timedate/timedated.c
+++ b/src/timedate/timedated.c
@@ -70,7 +70,7 @@ static int context_read_data(Context *c) {
 
         r = get_timezone(&t);
         if (r == -EINVAL)
-                log_warning_errno(r, "/etc/localtime should be a symbolic link to a time zone data file in /usr/share/zoneinfo/.");
+                log_warning_errno(r, "/etc/localtime should be a symbolic link to a time zone data file in /etc/zoneinfo/.");
         else if (r < 0)
                 log_warning_errno(r, "Failed to get target of /etc/localtime: %m");
 
@@ -96,7 +96,7 @@ static int context_write_data_timezone(Context *c) {
                 return r;
         }
 
-        p = strappend("../usr/share/zoneinfo/", c->zone);
+        p = strappend("zoneinfo/", c->zone);
         if (!p)
                 return log_oom();
 

--- a/tmpfiles.d/etc.conf.m4
+++ b/tmpfiles.d/etc.conf.m4
@@ -8,7 +8,7 @@
 # See tmpfiles.d(5) for details
 
 L /etc/os-release - - - - ../usr/lib/os-release
-L /etc/localtime - - - - ../usr/share/zoneinfo/UTC
+L /etc/localtime - - - - zoneinfo/UTC
 L+ /etc/mtab - - - - ../proc/self/mounts
 m4_ifdef(`HAVE_SMACK_RUN_LABEL',
 t /etc/mtab - - - - security.SMACK64=_


### PR DESCRIPTION
This is needed to fix `timedatectl` to properly show time zones (and possibly to fix other places where systemd uses timezones). A patch is needed into NixOS, too, but this can be safely merged and used separately.

Partially fixes https://github.com/NixOS/nixpkgs/issues/19339, related: https://github.com/NixOS/nixpkgs/pull/19449

This is essentially:

```
> find -type f -exec sed -i 's,\.\./usr/share/zoneinfo,zoneinfo,g' {} \;
> find -type f -exec sed -i 's,/usr/share/zoneinfo,/etc/zoneinfo,g' {} \;
```
