### PR TITLE
localectl: use /etc/X11/xkb for list-x11-*

### DIFF
--- a/src/locale/localectl.c
+++ b/src/locale/localectl.c
@@ -394,7 +394,7 @@ static int list_x11_keymaps(sd_bus *bus, char **args, unsigned n) {
                 return -EINVAL;
         }
 
-        f = fopen("/usr/share/X11/xkb/rules/base.lst", "re");
+        f = fopen("/etc/X11/xkb/rules/base.lst", "re");
         if (!f)
                 return log_error_errno(errno, "Failed to open keyboard mapping list. %m");
 


### PR DESCRIPTION
NixOS has an option to link the xkb data files to /etc/X11, but not to
/usr/share/X11.

fixes NixOS/nixpkgs#19629 (tested)
