### PR TITLE
resolved: fix loop on packets with pseudo dns types (CVE-2017-15908)

### DIFF
--- a/src/resolve/resolved-dns-packet.c
+++ b/src/resolve/resolved-dns-packet.c
@@ -1503,7 +1503,7 @@ static int dns_packet_read_type_window(DnsPacket *p, Bitmap **types, size_t *sta
 
                 found = true;
 
-                while (bitmask) {
+                for (; bitmask; bit++, bitmask >>= 1)
                         if (bitmap[i] & bitmask) {
                                 uint16_t n;
 
@@ -1517,10 +1517,6 @@ static int dns_packet_read_type_window(DnsPacket *p, Bitmap **types, size_t *sta
                                 if (r < 0)
                                         return r;
                         }
-
-                        bit++;
-                        bitmask >>= 1;
-                }
         }
 
         if (!found)


### PR DESCRIPTION
This is a cherry-pick of the upstream fix for CVE-2017-15908.