### PR TITLE
Revert "units: order systemd-user-sessions.service after network.target"

### DIFF
--- a/units/systemd-user-sessions.service.in
+++ b/units/systemd-user-sessions.service.in
@@ -10,7 +10,7 @@
 [Unit]
 Description=Permit User Sessions
 Documentation=man:systemd-user-sessions.service(8)
-After=remote-fs.target nss-user-lookup.target network.target
+After=remote-fs.target nss-user-lookup.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Revert upstream commit 8c856804780681e135d98ca94d08afe247557770

Fixes https://github.com/NixOS/nixpkgs/issues/60900

Please see the discussion at https://github.com/NixOS/nixpkgs/pull/61098 for context. If I understand correctly, mass rebuild shouldn't be an issue for the next release since we are upgrading systemd anyway.